### PR TITLE
Handle video play promise rejections

### DIFF
--- a/Presentation/files/js/canvas.js
+++ b/Presentation/files/js/canvas.js
@@ -182,10 +182,14 @@ DM.Canvas = Class.create({
 	resumePanels: function () {
 	    _canvas.fullScreenActive = false;
 	    _canvas.panels.forEach(function (p) {
-	        try {
-	            if (p.object && typeof p.object.play === "function")
-	                p.object.play();
-	        } catch (e) { }
+                try {
+                    if (p.object && typeof p.object.play === "function") {
+                        var playResult = p.object.play();
+                        if (playResult && typeof playResult.catch === "function") {
+                            playResult.catch(function () { });
+                        }
+                    }
+                } catch (e) { }
 	    });
 	},
 

--- a/Presentation/files/js/video.js
+++ b/Presentation/files/js/video.js
@@ -40,7 +40,12 @@ DM.Video = Class.create(DM.FrameBase, {
             video.insert({ top: e });
         });
 
-        if (options.play) video.play();
+        if (options.play) {
+            var playPromise = video.play();
+            if (playPromise && typeof playPromise.catch === "function") {
+                playPromise.catch(function () { });
+            }
+        }
     },
 
     stop: function ($super) {
@@ -58,7 +63,10 @@ DM.Video = Class.create(DM.FrameBase, {
     play: function ($super) {
         "use strict";
         $super();
-        this.video.play();
+        var playPromise = this.video.play();
+        if (playPromise && typeof playPromise.catch === "function") {
+            playPromise.catch(function () { });
+        }
     },
 
     uninit: function ($super) {


### PR DESCRIPTION
## Summary
- add promise rejection handling around all invocations of `video.play()`
- guard panel resume playback to swallow promise rejections

## Testing
- not run (browser console verification required)


------
https://chatgpt.com/codex/tasks/task_e_68c99884b6308325b51f3bb0015601dd