### PR TITLE
Serve videos inline by default

### DIFF
--- a/Presentation/getVideo.ashx.cs
+++ b/Presentation/getVideo.ashx.cs
@@ -35,6 +35,7 @@ namespace DisplayMonkey
             int frameId = request.IntOrZero("frame");
             int contentId = request.IntOrZero("content");
             int trace = request.IntOrZero("trace");
+            bool forceDownload = request.IntOrZero("download") != 0;
             
             try
 			{
@@ -96,10 +97,12 @@ namespace DisplayMonkey
 				}
 
 				response.ContentType = mimeType;
-				response.AddHeader("Content-Disposition", string.Format(
-					"attachment; filename=\"{0}\"",
-					mediaName
-					));
+                                string dispositionType = forceDownload ? "attachment" : "inline";
+                                response.AddHeader("Content-Disposition", string.Format(
+                                        "{0}; filename=\"{1}\"",
+                                        dispositionType,
+                                        mediaName
+                                        ));
 				response.AddHeader("Content-Length", data.Length.ToString());
 			}
 


### PR DESCRIPTION
## Summary
- default video responses to inline Content-Disposition so browsers play inline
- allow opt-in attachment downloads via an optional `download` query flag

## Testing
- `dotnet build DisplayMonkey.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0ab45c088325bd97a11da80f36fa